### PR TITLE
Kurikulum Link Backend Implementation

### DIFF
--- a/app/Http/Controllers/KurikulumController.php
+++ b/app/Http/Controllers/KurikulumController.php
@@ -37,4 +37,15 @@ class KurikulumController extends Controller
 
         return redirect()->back()->with('message', 'Kurikulum berhasil diubah');
     }
+
+    public function destroy(Kurikulum $kurikulum): RedirectResponse
+    {
+        if (!auth()->user()->isAdminSuper()) {
+            abort(403);
+        }
+
+        $kurikulum->delete();
+
+        return redirect()->back()->with('message', 'Kurikulum berhasil dihapus');
+    }
 }

--- a/app/Http/Controllers/KurikulumController.php
+++ b/app/Http/Controllers/KurikulumController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Kurikulum;
+use Inertia\Response;
+
+class KurikulumController extends Controller
+{
+    public function index(): Response
+    {
+        $kurikulum = Kurikulum::all();
+
+        $props = [
+            'kurikulum' => $kurikulum,
+        ];
+
+        return inertia("Curriculum/index", $props);
+    }
+}

--- a/app/Http/Controllers/KurikulumController.php
+++ b/app/Http/Controllers/KurikulumController.php
@@ -28,4 +28,13 @@ class KurikulumController extends Controller
 
         return redirect()->back()->with('message', 'Kurikulum berhasil ditambahkan');
     }
+
+    public function update(KurikulumCreateRequest $request, Kurikulum $kurikulum): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        $kurikulum->update($validated);
+
+        return redirect()->back()->with('message', 'Kurikulum berhasil diubah');
+    }
 }

--- a/app/Http/Controllers/KurikulumController.php
+++ b/app/Http/Controllers/KurikulumController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\KurikulumCreateRequest;
 use App\Models\Kurikulum;
+use Illuminate\Http\RedirectResponse;
 use Inertia\Response;
 
 class KurikulumController extends Controller
@@ -16,5 +18,14 @@ class KurikulumController extends Controller
         ];
 
         return inertia("Curriculum/index", $props);
+    }
+
+    public function store(KurikulumCreateRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        Kurikulum::create($validated);
+
+        return redirect()->back()->with('message', 'Kurikulum berhasil ditambahkan');
     }
 }

--- a/app/Http/Requests/KurikulumCreateRequest.php
+++ b/app/Http/Requests/KurikulumCreateRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class KurikulumCreateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return auth()->user()->isAdminSuper();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'judul' => ['required', 'string', 'max:50'],
+            'url' => ['required', 'string', 'url'],
+        ];
+    }
+}

--- a/app/Models/Kurikulum.php
+++ b/app/Models/Kurikulum.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Kurikulum extends Model
+{
+    use HasFactory;
+
+    protected $table = 'kurikulum';
+
+    protected $fillable = [
+        'judul',
+        'url',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+}

--- a/database/factories/KurikulumFactory.php
+++ b/database/factories/KurikulumFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Kurikulum>
+ */
+class KurikulumFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'judul' => fake()->sentence(3),
+            'url' => fake()->url(),
+            'created_at' => fake()->dateTimeBetween('-1 year', 'now'),
+            'updated_at' => function (array $attributes) {
+                return $this->faker->boolean(50)
+                    ? $this->faker->dateTimeBetween($attributes['created_at'], 'now')
+                    : $attributes['created_at'];
+            }
+        ];
+    }
+}

--- a/database/migrations/2025_01_16_152351_create_kurikulum_table.php
+++ b/database/migrations/2025_01_16_152351_create_kurikulum_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('kurikulum', function (Blueprint $table) {
+            $table->id();
+            $table->string('judul', 50);
+            $table->string('url');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('kurikulum');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,6 +18,7 @@ class DatabaseSeeder extends Seeder
             PengurusSeeder::class,
             UnitSeeder::class,
             PengurusUnitSeeder::class,
+            KurikulumSeeder::class,
         ]);
     }
 }

--- a/database/seeders/KurikulumSeeder.php
+++ b/database/seeders/KurikulumSeeder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Kurikulum;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class KurikulumSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $predefinedJudul = [
+            'Buku Kurikulum PN CHYBK',
+            'Implementasi KPN CHYBK',
+            'Panduan Pembelajaran dan Asesmen',
+            'Panduan Desain Pembelajaran',
+            'Model Pembelajaran KPN CHYBK',
+            'Taksonomi Bloom',
+            'Instrumen SPMI Akademik',
+            'Pedoman Akademik',
+            'Kalender Akademik',
+            'Guru YLM Berbagi',
+            'Upload Perangkat untuk SPMI',
+        ];
+
+        foreach ($predefinedJudul as $judul) {
+            Kurikulum::factory()->create([
+                'judul' => $judul,
+            ]);
+        }
+    }
+}

--- a/resources/js/Pages/Curriculum/index.tsx
+++ b/resources/js/Pages/Curriculum/index.tsx
@@ -1,12 +1,13 @@
 import Layout from '@/Layout';
 import Landing from './sections/Landing';
 import List from './sections/List';
+import { KurikulumItem } from "@/models/kurikulum";
 
-const Curriculum = () => {
+const Curriculum = ({ kurikulum }: { kurikulum: KurikulumItem[] }) => {
     return (
         <Layout>
             <Landing />
-            <List />
+            <List kurikulum={kurikulum} />
         </Layout>
     );
 };

--- a/resources/js/Pages/Curriculum/sections/List.tsx
+++ b/resources/js/Pages/Curriculum/sections/List.tsx
@@ -1,3 +1,5 @@
+import { KurikulumItem } from "@/models/kurikulum";
+
 const data = [
     {
         id: 1,
@@ -56,18 +58,19 @@ const data = [
     },
 ];
 
-const List = () => {
+const List = ({ kurikulum }: { kurikulum: KurikulumItem[] }) => {
     return (
         <div className="-mt-[80px] flex min-h-screen w-full justify-center bg-[url(/images/bg-ListCurriculum.webp)] bg-cover bg-top bg-no-repeat font-poppins">
             <div className="mt-64 flex w-[80%] flex-col items-center justify-center gap-12 pb-20">
-                {data.map((item) => (
+                {kurikulum.map((item: KurikulumItem) => (
                     <a
                         key={item.id}
-                        href={item.link}
+                        href={item.url}
                         target="_blank"
                         className="w-[60%] rounded-[20px] bg-dark-blue py-4 text-center text-lg font-semibold text-white shadow-md hover:bg-white hover:text-black"
+                        rel="noreferrer"
                     >
-                        {item.title}
+                        {item.judul}
                     </a>
                 ))}
             </div>

--- a/resources/js/models/kurikulum.ts
+++ b/resources/js/models/kurikulum.ts
@@ -1,0 +1,5 @@
+export interface KurikulumItem {
+    id: number;
+    judul: string;
+    url: string;
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,6 +38,9 @@ Route::get('/kurikulum', [KurikulumController::class, 'index'])
 Route::post('/kurikulum', [KurikulumController::class, 'store'])
     ->name('kurikulum.store')
     ->middleware(RequireAdminMiddleware::class);
+Route::put('/kurikulum/{kurikulum}', [KurikulumController::class, 'update'])
+    ->name('kurikulum.update')
+    ->middleware(RequireAdminMiddleware::class);
 
 Route::get('/berita', [BeritaController::class, 'index'])->name('berita.index');
 Route::post('/berita', [BeritaController::class, 'store'])

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,9 @@ Route::post('/kurikulum', [KurikulumController::class, 'store'])
 Route::put('/kurikulum/{kurikulum}', [KurikulumController::class, 'update'])
     ->name('kurikulum.update')
     ->middleware(RequireAdminMiddleware::class);
+Route::delete('/kurikulum/{kurikulum}', [KurikulumController::class, 'destroy'])
+    ->name('kurikulum.destroy')
+    ->middleware(RequireAdminMiddleware::class);
 
 Route::get('/berita', [BeritaController::class, 'index'])->name('berita.index');
 Route::post('/berita', [BeritaController::class, 'store'])

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,9 @@ Route::put('/pengurus/{pengurus}', [PengurusController::class, 'update'])
 
 Route::get('/kurikulum', [KurikulumController::class, 'index'])
     ->name('kurikulum');
+Route::post('/kurikulum', [KurikulumController::class, 'store'])
+    ->name('kurikulum.store')
+    ->middleware(RequireAdminMiddleware::class);
 
 Route::get('/berita', [BeritaController::class, 'index'])->name('berita.index');
 Route::post('/berita', [BeritaController::class, 'store'])

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\BeritaController;
 use App\Http\Controllers\GaleriController;
 use App\Http\Controllers\HomePageController;
+use App\Http\Controllers\KurikulumController;
 use App\Http\Controllers\PengurusController;
 use App\Http\Controllers\UnitController;
 use App\Http\Middleware\RequireAdminMiddleware;
@@ -32,9 +33,8 @@ Route::put('/pengurus/{pengurus}', [PengurusController::class, 'update'])
     ->name('pengurus.update')
     ->middleware(RequireAdminMiddleware::class);
 
-Route::get('/kurikulum', function () {
-    return inertia("Curriculum/index");
-});
+Route::get('/kurikulum', [KurikulumController::class, 'index'])
+    ->name('kurikulum');
 
 Route::get('/berita', [BeritaController::class, 'index'])->name('berita.index');
 Route::post('/berita', [BeritaController::class, 'store'])


### PR DESCRIPTION
This PR implements a complete Kurikulum (Curriculum) management system with CRUD operations.

Database Structure:
- id: Primary key
- judul: String (max 50 chars) - stores curriculum title
- url: String - stores curriculum resource URL
- timestamps: Created and updated timestamps

Routes:
- GET /kurikulum - View all curriculum entries (**I've successfully integrated it with the frontend**)
- POST /kurikulum - Create new curriculum (super admin only)
- PUT /kurikulum/{kurikulum} - Update existing curriculum (super admin only)
- DELETE /kurikulum/{kurikulum} - Delete curriculum (super admin only)

Authorization:
- Regular users can only view curriculum
- Create, Update, and Delete operation restricted to super admin users

Testing:
- Factory included for generating test data
- Seeder provides initial curriculum entries

Note:
- Run `php artisan migrate:fresh --seed`